### PR TITLE
Support older R versions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Description: Wrapper for Nokia's HERE geocoding API. See http://here.com/ for
     more information on HERE and https://developer.here.com/geocoder for more
     information on the HERE geocoding API.
 Depends:
-    R (>= 3.1.1)
+    R (>= 3.0.0)
 License: MIT + file LICENSE
 LazyData: true
 Imports:


### PR DESCRIPTION
Thanks for the neat package!

I'm not sure if this was by design or not, but I went to use your package on a slightly older version of R (3.0.x) and found it wasn't supported just by merit of the minimum requirements in your `DESCRIPTION`. I changed the minimum back to a lower version and was able to install it and use it successfully. 

Thought I'd offer this change to widen your audience a bit. Of course, users would need to install from GitHub, perhaps using devtools to get this fix.
